### PR TITLE
feat: write per-channel assets.json paths alongside legacy file

### DIFF
--- a/.github/workflows/update-release-assets.yaml
+++ b/.github/workflows/update-release-assets.yaml
@@ -59,19 +59,30 @@ jobs:
       - name: Download release assets from R2
         env:
           VERSION: ${{ steps.params.outputs.version }}
+          CHANNEL: ${{ steps.params.outputs.channel }}
         run: |
           BASE_URL="https://r2.kunobi.ninja/v${VERSION}"
           VERSIONED_FILE="Kunobi_${VERSION}_release_assets.json"
 
+          # Legacy path — latest-of-any-channel pointer.
+          # Kept for backward compatibility with consumers that read this exact path.
           curl -fSL "${BASE_URL}/${VERSIONED_FILE}" -o releases/assets.json
           curl -fSL "${BASE_URL}/${VERSIONED_FILE}.sha256" -o releases/assets.json.sha256
 
+          # Per-channel paths — let consumers track stable and unstable independently.
+          mkdir -p "releases/${CHANNEL}"
+          cp releases/assets.json        "releases/${CHANNEL}/assets.json"
+          cp releases/assets.json.sha256 "releases/${CHANNEL}/assets.json.sha256"
+
           ls -lh releases/assets.json releases/assets.json.sha256
+          ls -lh "releases/${CHANNEL}/assets.json" "releases/${CHANNEL}/assets.json.sha256"
 
       - name: Check for changes
         id: diff
+        env:
+          CHANNEL: ${{ steps.params.outputs.channel }}
         run: |
-          if git diff --quiet releases/assets.json 2>/dev/null; then
+          if git diff --quiet releases/assets.json "releases/${CHANNEL}/assets.json" 2>/dev/null; then
             echo "changed=false" >> $GITHUB_OUTPUT
             echo "ℹ️ Release assets already up to date, skipping"
           else
@@ -84,13 +95,15 @@ jobs:
         id: branch
         env:
           VERSION: ${{ steps.params.outputs.version }}
+          CHANNEL: ${{ steps.params.outputs.channel }}
         run: |
           BRANCH="bot/update-${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add releases/assets.json releases/assets.json.sha256
-          git commit -m "[Bot] Update Kunobi to ${VERSION}"
+          git add releases/assets.json releases/assets.json.sha256 \
+                  "releases/${CHANNEL}/assets.json" "releases/${CHANNEL}/assets.json.sha256"
+          git commit -m "[Bot] Update Kunobi to ${VERSION} (${CHANNEL})"
           git push origin "$BRANCH" || git push --force origin "$BRANCH"
           echo "name=$BRANCH" >> $GITHUB_OUTPUT
           echo "✅ New branch ${BRANCH} created"

--- a/.github/workflows/update-release-assets.yaml
+++ b/.github/workflows/update-release-assets.yaml
@@ -70,6 +70,16 @@ jobs:
             CHANNEL="$CHANNEL_RAW"
           fi
 
+          # Channel goes into a filesystem path below — reject anything that
+          # isn't a known value to prevent path traversal or stray directories.
+          case "$CHANNEL" in
+            stable|unstable) ;;
+            *)
+              echo "Error: unknown channel '$CHANNEL' (expected 'stable' or 'unstable')" >&2
+              exit 1
+              ;;
+          esac
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
           echo "✅ Updating to version: $VERSION (channel: $CHANNEL)"

--- a/.github/workflows/update-release-assets.yaml
+++ b/.github/workflows/update-release-assets.yaml
@@ -9,13 +9,13 @@ on:
         description: 'Version to update to (without v prefix)'
         required: true
       channel:
-        description: 'Release channel (stable, unstable)'
-        required: true
+        description: 'Release channel (defaults to stable if omitted; pre-release versions require explicit unstable)'
+        required: false
         type: choice
         options:
           - stable
           - unstable
-        default: unstable
+        default: stable
 
 jobs:
   update-release-assets:
@@ -41,15 +41,33 @@ jobs:
         run: |
           if [ "$EVENT_NAME" = "repository_dispatch" ]; then
             VERSION="$DISPATCH_VERSION"
-            CHANNEL="$DISPATCH_CHANNEL"
+            CHANNEL_RAW="$DISPATCH_CHANNEL"
           else
             VERSION="$INPUT_VERSION"
-            CHANNEL="$INPUT_CHANNEL"
+            CHANNEL_RAW="$INPUT_CHANNEL"
           fi
 
-          if [ -z "$VERSION" ] || [ -z "$CHANNEL" ]; then
-            echo "Error: ❌ version and channel are required" >&2
+          if [ -z "$VERSION" ]; then
+            echo "Error: ❌ version is required" >&2
             exit 1
+          fi
+
+          # Backward compatibility: callers that don't send `channel` are
+          # treated as stable. To prevent a pre-release version from silently
+          # landing on the stable channel, the version must match the stable
+          # SemVer pattern (^x.y.z$) when channel is defaulted.
+          if [ -z "$CHANNEL_RAW" ]; then
+            if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              CHANNEL="stable"
+              echo "ℹ️ channel not provided — defaulted to 'stable' (version matches stable pattern)"
+            else
+              echo "Error: channel not provided and version '$VERSION' does not match the stable" >&2
+              echo "       pattern (^[0-9]+\\.[0-9]+\\.[0-9]+\$). Refusing to default to stable for" >&2
+              echo "       a pre-release version. Please pass channel explicitly." >&2
+              exit 1
+            fi
+          else
+            CHANNEL="$CHANNEL_RAW"
           fi
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-release-assets.yaml
+++ b/.github/workflows/update-release-assets.yaml
@@ -107,10 +107,11 @@ jobs:
 
       - name: Check for changes
         id: diff
-        env:
-          CHANNEL: ${{ steps.params.outputs.channel }}
         run: |
-          if git diff --quiet releases/assets.json "releases/${CHANNEL}/assets.json" 2>/dev/null; then
+          # Use git status (not git diff) so newly created untracked files
+          # under releases/ are also counted as changes — e.g. the first time
+          # `releases/${CHANNEL}/` is materialized for a channel.
+          if [ -z "$(git status --porcelain releases/)" ]; then
             echo "changed=false" >> $GITHUB_OUTPUT
             echo "ℹ️ Release assets already up to date, skipping"
           else

--- a/releases/stable/assets.json
+++ b/releases/stable/assets.json
@@ -1,0 +1,41 @@
+{
+  "version": "1.0.0",
+  "channel": "stable",
+  "pub_date": "2026-05-05T18:09:44Z",
+  "platforms": {
+    "darwin-aarch64": [
+      {
+        "sha256": "083bf05df5afc1d2dd7bd2838548c7745895bb5158d404512d403a8218953e62",
+        "url": "https://r2.kunobi.ninja/v1.0.0/Kunobi_1.0.0_darwin_aarch64.app.tar.gz"
+      },
+      {
+        "sha256": "a6b6dc23ed6fa608b4b565643c14f045ec9f26b0fd35b23b94a7abf5d216bf77",
+        "url": "https://r2.kunobi.ninja/v1.0.0/Kunobi_1.0.0_darwin_aarch64.dmg"
+      }
+    ],
+    "linux-x86_64": [
+      {
+        "sha256": "7e8092c968658ba2fbc1caf9a05eb8b65835daa2319af235bb11014db15327cb",
+        "url": "https://r2.kunobi.ninja/v1.0.0/Kunobi_1.0.0_linux_x86_64.AppImage"
+      },
+      {
+        "sha256": "20f8c869e5b5e297255dde733af1848f948193af27c6fa8a065cf991af29809e",
+        "url": "https://r2.kunobi.ninja/v1.0.0/Kunobi_1.0.0_linux_x86_64.deb"
+      },
+      {
+        "sha256": "9a36a4e9251ab9961e59313b0d572e55519b28f384ee83266d6198ef4569ce4b",
+        "url": "https://r2.kunobi.ninja/v1.0.0/Kunobi_1.0.0_linux_x86_64.rpm"
+      },
+      {
+        "sha256": "a841b37e1b0998c3eed460b316067be4dfc9f0a920d77bf7b0723963096d035f",
+        "url": "https://r2.kunobi.ninja/v1.0.0/Kunobi_1.0.0_linux_x86_64.tar.gz"
+      }
+    ],
+    "windows-x86_64": [
+      {
+        "sha256": "32cafa08a44e3d16c7beaefb7b7baec958450d8ebc5c828ac4c0aacbb9dce9c2",
+        "url": "https://r2.kunobi.ninja/v1.0.0/Kunobi_1.0.0_windows_x86_64.exe"
+      }
+    ]
+  }
+}

--- a/releases/stable/assets.json.sha256
+++ b/releases/stable/assets.json.sha256
@@ -1,0 +1,1 @@
+b00b0fa0a7517cb57ed89ec642b833d699ac317f9b8b31d27ea71dfc48e29213  Kunobi_1.0.0_release_assets.json

--- a/releases/unstable/assets.json
+++ b/releases/unstable/assets.json
@@ -1,0 +1,41 @@
+{
+  "version": "0.1.0-beta.34",
+  "channel": "unstable",
+  "pub_date": "2026-05-05T16:34:06Z",
+  "platforms": {
+    "darwin-aarch64": [
+      {
+        "sha256": "ac27d212272339bc11b6d66c94d29191705ac736db3a4f63fff1aec5364ed698",
+        "url": "https://r2.kunobi.ninja/v0.1.0-beta.34/Kunobi_0.1.0-beta.34_darwin_aarch64.app.tar.gz"
+      },
+      {
+        "sha256": "8670541a89c952c53099a2039a46f00718b0e5f281abffbbe4cdc1d53c2522ee",
+        "url": "https://r2.kunobi.ninja/v0.1.0-beta.34/Kunobi_0.1.0-beta.34_darwin_aarch64.dmg"
+      }
+    ],
+    "linux-x86_64": [
+      {
+        "sha256": "894213baa88b8b3c5a7dbf38f99a12f7c2db1519b1ba7bcbbaf07270c8733390",
+        "url": "https://r2.kunobi.ninja/v0.1.0-beta.34/Kunobi_0.1.0-beta.34_linux_x86_64.AppImage"
+      },
+      {
+        "sha256": "d3ed2c222acafac462db0d9b6df1140b1ca168435401c5f17f5db630001267c3",
+        "url": "https://r2.kunobi.ninja/v0.1.0-beta.34/Kunobi_0.1.0-beta.34_linux_x86_64.deb"
+      },
+      {
+        "sha256": "c86e30042d4b69259757c1fa7f641720440bf9efb9029098f01e8827f402c82e",
+        "url": "https://r2.kunobi.ninja/v0.1.0-beta.34/Kunobi_0.1.0-beta.34_linux_x86_64.rpm"
+      },
+      {
+        "sha256": "ddfffd5129e4797791ebcb400275ee218c6b145e4d1310dd006ba67508416708",
+        "url": "https://r2.kunobi.ninja/v0.1.0-beta.34/Kunobi_0.1.0-beta.34_linux_x86_64.tar.gz"
+      }
+    ],
+    "windows-x86_64": [
+      {
+        "sha256": "a1b375f59c394fc685b7f86031d6231b30063e1d8086498e1c6637be80169e31",
+        "url": "https://r2.kunobi.ninja/v0.1.0-beta.34/Kunobi_0.1.0-beta.34_windows_x86_64.exe"
+      }
+    ]
+  }
+}

--- a/releases/unstable/assets.json.sha256
+++ b/releases/unstable/assets.json.sha256
@@ -1,0 +1,1 @@
+5f7a0650223d40fc934b409c651fc613a5d213b60b5bcec62da25f834af43226  Kunobi_0.1.0-beta.34_release_assets.json


### PR DESCRIPTION
## What changes

The bot now writes:

- `releases/assets.json` — **unchanged behavior**, latest of any channel. Kept for backward compatibility with consumers that read this exact path (e.g. the website).
- `releases/{stable,unstable}/assets.json` — **new**, lets consumers track stable and unstable independently.

Both files are committed in the same PR; both are sha256-pinned; the legacy file is what `create-release.yaml` watches for path-triggered GitHub release creation, so that flow is unchanged.

## Why additive, not a path move

A search across `kunobi-ninja`, `Zondax`, and `aquaproj` orgs found no reader of `releases/assets.json` other than this repo's own `create-release.yaml`. Aqua/mise discover versions via GitHub release tags (`version_source: github_tag`), not via this file. The most likely remaining consumer is the kunobi.ninja website (private/external source). Adding new paths next to the legacy one removes the risk of breaking an unknown consumer.

## Companion changes

- `Zondax/kunobi-frontend` PR #1514 — pipeline plumbs `channel` into the dispatch payload (already passed today, but confirmed required end-to-end).
- `kunobi-ninja/homebrew-kunobi` (separate PR) — adds the `kunobi-unstable` cask and channel-aware receiver routing.

## Forward-compat note

The existing `releases/assets.json` was never lost — it was just channel-blind. After this PR, a consumer that wants "latest stable" can switch to `releases/stable/assets.json` cleanly; the legacy path keeps working.