### PR TITLE
docs(readme): document unstable channel for Homebrew, Chocolatey, winget

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,41 +34,64 @@ The whole thing runs natively on your OS. No bundled Chromium, no Electron, no N
 
 Download from [kunobi.ninja/download](https://kunobi.ninja/download). Available for macOS, Linux, and Windows.
 
+Two channels are available across all package managers:
+
+| Channel | Description | Who should use it |
+|---------|-------------|-------------------|
+| `stable` | Production releases | Most users |
+| `unstable` | Pre-releases (RC, beta, alpha) | Testers and early adopters |
+
+Stable and unstable share the same `Kunobi.app` bundle and bundle identifier (`ninja.kunobi.desktop`); they cannot coexist on the same machine. Pick a channel; switching means uninstalling and reinstalling.
+
 ### Homebrew (macOS)
 
 ```bash
 brew tap kunobi-ninja/kunobi  # If not already added
+
+# Stable
 brew install --cask kunobi
+
+# Unstable (pre-releases)
+brew install --cask kunobi-unstable
 ```
 
-The cask is maintained at [kunobi-ninja/homebrew-kunobi](https://github.com/kunobi-ninja/homebrew-kunobi).
+`brew` will refuse to install one cask while the other is present. To switch channels:
+
+```bash
+brew uninstall --cask kunobi && brew install --cask kunobi-unstable
+```
+
+The casks are maintained at [kunobi-ninja/homebrew-kunobi](https://github.com/kunobi-ninja/homebrew-kunobi).
 
 ### Chocolatey (Windows)
 
 ```powershell
+# Stable
 choco install kunobi
+
+# Unstable (pre-releases)
+choco install kunobi --pre
 ```
+
+Stable and unstable share a single Chocolatey package; the `--pre` flag opts into pre-release versions. Use `choco upgrade kunobi --pre` to keep an unstable install up to date.
 
 The package is maintained at [kunobi-ninja/chocolatey-kunobi](https://github.com/kunobi-ninja/chocolatey-kunobi).
 
 ### Winget (Windows)
 
 ```powershell
+# Stable
 winget install kunobi-ninja.kunobi
+
+# Unstable (pre-releases)
+winget install kunobi-ninja.kunobi.Unstable
 ```
 
-The package is maintained at [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs). Manifest PRs are submitted automatically from the [kunobi-ninja/winget-pkgs](https://github.com/kunobi-ninja/winget-pkgs) fork.
+The packages are maintained at [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs). Manifest PRs are submitted automatically from the [kunobi-ninja/winget-pkgs](https://github.com/kunobi-ninja/winget-pkgs) fork.
 
 ### APT (Linux)
 
-Kunobi publishes `.deb` packages to a self-hosted APT repository. Two channels are available:
-
-| Channel | Description | Who should use it |
-|---------|-------------|-------------------|
-| `stable` | Production releases | Most users |
-| `unstable` | Pre-releases (RC, Beta, Alpha) | Testers and early adopters |
-
-Stable releases are automatically promoted to the unstable channel, so unstable users always receive stable updates too.
+Kunobi publishes `.deb` packages to a self-hosted APT repository with one suite per channel. Stable releases are also promoted into the unstable suite, so unstable subscribers receive stable updates too.
 
 #### Setup
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Two channels are available across all package managers:
 | `stable` | Production releases | Most users |
 | `unstable` | Pre-releases (RC, beta, alpha) | Testers and early adopters |
 
-Stable and unstable share the same `Kunobi.app` bundle and bundle identifier (`ninja.kunobi.desktop`); they cannot coexist on the same machine. Pick a channel; switching means uninstalling and reinstalling.
+Stable and unstable install the same Kunobi binary; only one channel can be installed at a time. Switching channels means uninstalling and reinstalling. The mechanism for selecting a channel differs per package manager — see each section below.
 
 ### Homebrew (macOS)
 
@@ -91,7 +91,7 @@ The packages are maintained at [microsoft/winget-pkgs](https://github.com/micros
 
 ### APT (Linux)
 
-Kunobi publishes `.deb` packages to a self-hosted APT repository with one suite per channel. Stable releases are also promoted into the unstable suite, so unstable subscribers receive stable updates too.
+Kunobi publishes `.deb` packages to a self-hosted APT repository with **one signed suite per channel**. The channel is selected by **which suite your `/etc/apt/sources.list.d/kunobi.list` subscribes to** — there's no separate package name. Stable releases are also promoted into the unstable suite, so unstable subscribers receive stable updates too.
 
 #### Setup
 


### PR DESCRIPTION
## What changes

The `## Install` section now documents the unstable channel for the three package managers that previously only showed the stable install command:

- **Homebrew**: adds `brew install --cask kunobi-unstable`
- **Chocolatey**: adds `choco install kunobi --pre`
- **winget**: adds `winget install kunobi-ninja.kunobi.Unstable`

Also adds a top-level channel table (mirrors the APT section's existing pattern) and a note that stable/unstable share the same `Kunobi.app` bundle and bundle identifier (`ninja.kunobi.desktop`), so users can only have one channel installed at a time.

## Why this is a separate PR

This was meant to land in #33 but the README change was committed and pushed *after* #33 had already been squash-merged into `main`, so it ended up on an orphan `feat/channel-split` branch that was never reattached to a PR. Splitting it out cleanly here.

The companion infrastructure that this README documents already shipped:
- `kunobi-ninja/homebrew-kunobi#25` (merged) — `kunobi-unstable` cask + receiver routing
- `kunobi-ninja/kunobi#33` (merged) — per-channel `releases/{stable,unstable}/assets.json` paths
- `Zondax/kunobi-frontend#1514` (open) — pipeline plumbs `channel` to receivers + winget identifier switch
- `kunobi-ninja/chocolatey-kunobi#16` (open) — nuspec `--pre` documentation